### PR TITLE
Add anonymous usage data analytics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 dist/
 node_modules/
 .DS_Store
+.env

--- a/README.md
+++ b/README.md
@@ -21,6 +21,14 @@ Available on **[Chrome Web Store](https://chrome.google.com/webstore/detail/powe
 
 ## Setup
 
+Create an `.env` file at the root of this repo directory.
+
+Currently the only enviroment variable is `STATS_DOMAIN` and is **not required** to run the project.
+
+```bash
+$ touch .env
+```
+
 Install the dependencies.
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Available on **[Chrome Web Store](https://chrome.google.com/webstore/detail/powe
 </div>
 
 ## Docs
+
 - [Privacy Policy](./privacy.md)
 
 ## Requirments

--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@ Available on **[Chrome Web Store](https://chrome.google.com/webstore/detail/powe
 
 </div>
 
+## Docs
+- [Privacy Policy](./privacy.md)
+
 ## Requirments
 
 - NodeJS >=10.16

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -18,4 +18,3 @@ This data is used for knowing if people are using the extension and what specifi
 No personally identifiable information (PII) is collected.
 
 The source code for how usage data is sent to Plausible can be found in my [Simple Plausible Tracker repository](https://github.com/anthonyec/simple_plausible_tracker).
-

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -1,0 +1,21 @@
+# Privacy Policy
+
+- Powerlet does not use cookies
+- Powerlet will not show you ads
+- Powerlet will not collect personally identifiable information (PII)
+- User data is not shared with third parties under any circumstances
+
+## Usage Data
+
+Powerlet uses a service called [Plausible Analytics](https://plausible.io/) to collect anonymous usage data.
+
+This data is used for knowing if people are using the extension and what specific features. Examples of the data:
+
+- 5 people in USA use the extension
+- 10 people opened the extension
+- 3 people clicked this button in the extension
+
+No personally identifiable information (PII) is collected.
+
+The source code for how usage data is sent to Plausible can be found in my [Simple Plausible Tracker repository](https://github.com/anthonyec/simple_plausible_tracker).
+

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -11,9 +11,9 @@ Powerlet uses a service called [Plausible Analytics](https://plausible.io/) to c
 
 This data is used for knowing if people are using the extension and what specific features. Examples of the data:
 
-- 5 people in USA use the extension
-- 10 people opened the extension
-- 3 people clicked this button in the extension
+- 20 people in USA use the extension
+- 30 people opened the extension
+- 10 people clicked this button in the extension
 
 No personally identifiable information (PII) is collected.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -6733,6 +6733,10 @@
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
       "dev": true
     },
+    "simple-plausible-tracker": {
+      "version": "git+https://github.com/anthonyec/simple_plausible_tracker.git#6f47191880eafc4d2a86a4344f8f14fb5b52714e",
+      "from": "git+https://github.com/anthonyec/simple_plausible_tracker.git#6f47191880eafc4d2a86a4344f8f14fb5b52714e"
+    },
     "slash": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6740,8 +6740,8 @@
       "dev": true
     },
     "simple-plausible-tracker": {
-      "version": "git+https://github.com/anthonyec/simple_plausible_tracker.git#6f47191880eafc4d2a86a4344f8f14fb5b52714e",
-      "from": "git+https://github.com/anthonyec/simple_plausible_tracker.git#6f47191880eafc4d2a86a4344f8f14fb5b52714e"
+      "version": "git+https://github.com/anthonyec/simple_plausible_tracker.git#0584220c975631d78fb2998f6ba538fe58aaa946",
+      "from": "git+https://github.com/anthonyec/simple_plausible_tracker.git#0584220c975631d78fb2998f6ba538fe58aaa946"
     },
     "slash": {
       "version": "1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2889,6 +2889,12 @@
         "domelementtype": "1"
       }
     },
+    "dotenv": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.2.0.tgz",
+      "integrity": "sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw==",
+      "dev": true
+    },
     "duplexify": {
       "version": "3.7.1",
       "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.7.1.tgz",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "redux": "^4.0.5",
     "redux-persist": "^6.0.0",
     "redux-thunk": "^2.3.0",
+    "simple-plausible-tracker": "git+https://github.com/anthonyec/simple_plausible_tracker.git#6f47191880eafc4d2a86a4344f8f14fb5b52714e",
     "use-callback-ref": "^1.2.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "clean-webpack-plugin": "^3.0.0",
     "copy-webpack-plugin": "^5.1.1",
     "css-loader": "^0.28.11",
+    "dotenv": "^8.2.0",
     "html-webpack-plugin": "^3.2.0",
     "mini-css-extract-plugin": "^0.9.0",
     "style-loader": "^0.20.3",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "build": "webpack --mode=production",
     "version": "node ./scripts/version.js && npm run format && git add ./src/manifest.json"
   },
-  "author": "",
+  "author": "Anthony Cossins",
   "license": "ISC",
   "dependencies": {
     "codemirror": "^5.52.2",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "redux": "^4.0.5",
     "redux-persist": "^6.0.0",
     "redux-thunk": "^2.3.0",
-    "simple-plausible-tracker": "git+https://github.com/anthonyec/simple_plausible_tracker.git#6f47191880eafc4d2a86a4344f8f14fb5b52714e",
+    "simple-plausible-tracker": "git+https://github.com/anthonyec/simple_plausible_tracker.git#0584220c975631d78fb2998f6ba538fe58aaa946",
     "use-callback-ref": "^1.2.1"
   },
   "devDependencies": {

--- a/src/popup/app.jsx
+++ b/src/popup/app.jsx
@@ -1,7 +1,8 @@
-import React, { Suspense } from 'react';
+import React, { Suspense, useEffect } from 'react';
+import { useDispatch } from 'react-redux';
 
 import zipObject from '../utils/zipObject';
-
+import { firePageView } from './store/actions/stats';
 import HomeScreen from './screens/home_screen';
 const SettingsScreen = React.lazy(() => import('./screens/settings'));
 const EditorScreen = React.lazy(() => import('./screens/editor_screen'));
@@ -10,6 +11,7 @@ import './reset.css';
 import './app.css';
 
 export default function App() {
+  const dispatch = useDispatch();
   const path = window.location.hash.replace('#', '').split('/');
   const base = path[0];
   const params = path.slice(1);
@@ -34,6 +36,10 @@ export default function App() {
   };
 
   const Screen = screens[base] ? screens[base] : screens.home;
+
+  useEffect(() => {
+    dispatch(firePageView());
+  }, [path]);
 
   return (
     <div className="app">

--- a/src/popup/index.js
+++ b/src/popup/index.js
@@ -7,7 +7,7 @@ import createStats from 'simple-plausible-tracker';
 import createStore from './store/index';
 import App from './app';
 
-const stats = createStats('powerlet.anthony.ec', {
+const stats = createStats(process.env.STATS_DOMAIN, {
   onFireError: (err) => {
     console.error(err);
   }

--- a/src/popup/index.js
+++ b/src/popup/index.js
@@ -2,14 +2,22 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import { Provider } from 'react-redux';
 import { persistStore } from 'redux-persist';
+import createStats from 'simple-plausible-tracker';
 
 import createStore from './store/index';
 import App from './app';
 
+const stats = createStats('powerlet.anthony.ec', {
+  onFireError: (err) => {
+    console.error(err);
+  }
+});
+
 const store = createStore(
   {},
   {
-    browser: chrome
+    browser: chrome,
+    stats
   }
 );
 

--- a/src/popup/store/actions/stats.js
+++ b/src/popup/store/actions/stats.js
@@ -1,5 +1,5 @@
 export function firePageView() {
   return async (dispatch, getState, { stats }) => {
     stats.fire('pageview');
-  }
+  };
 }

--- a/src/popup/store/actions/stats.js
+++ b/src/popup/store/actions/stats.js
@@ -1,0 +1,5 @@
+export function firePageView() {
+  return async (dispatch, getState, { stats }) => {
+    stats.fire('pageview');
+  }
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -54,7 +54,7 @@ module.exports = {
       allChunks: true
     }),
     new webpack.DefinePlugin({
-      "process.env": JSON.stringify(env.parsed)
+      'process.env': JSON.stringify(env.parsed)
     })
   ]
 };

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,8 +1,10 @@
 const path = require('path');
+const webpack = require('webpack');
 const { CleanWebpackPlugin } = require('clean-webpack-plugin');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const CopyPlugin = require('copy-webpack-plugin');
+const env = require('dotenv').config();
 
 module.exports = {
   entry: {
@@ -50,6 +52,9 @@ module.exports = {
     new MiniCssExtractPlugin({
       filename: 'popup.[contentHash:5].css',
       allChunks: true
+    }),
+    new webpack.DefinePlugin({
+      "process.env": JSON.stringify(env.parsed)
     })
   ]
 };


### PR DESCRIPTION
## Summary
I'd like to add new features but before I do I'd like to know if people actually use the extension. I don't like full blown analytics like Google Analytics because I don't like how the data is used and collected.

What I've implemented is essentially a counter. Letting me see how many times the extension is opened and eventually what buttons people click. It won't be tied to a personal ID.

## Changes
- Add anonymous usage data stats
- Add privacy policy
- Add `dotenv` library to pull in `STATS_DOMAIN`
- Update README