### PR TITLE
Add support for translations

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -1,0 +1,26 @@
+{
+  "search_scripts_placeholder": {
+    "message": "Search scripts",
+    "description": "Placeholder displayed in the search field for filtering scripts"
+  },
+  "recently_used_heading": {
+    "message": "Recently used",
+    "description": "Heading title for recently used scripts"
+  },
+  "other_scripts_heading": {
+    "message": "Other scripts",
+    "description": "Heading title for other un-grouped scripts"
+  },
+  "no_search_results_message": {
+    "message": "No scripts found.",
+    "description": ""
+  },
+  "empty_state_message": {
+    "message": "You don't have any bookmark scripts.",
+    "description": ""
+  },
+  "add_scripts_button": {
+    "message": "Add scripts",
+    "description": ""
+  }
+}

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -16,7 +16,7 @@
     "description": "Shown when a search returns no results"
   },
   "empty_state_message": {
-    "message": "You don't have any bookmark scripts.",
+    "message": "You don't have any bookmarklets.",
     "description": "Shown when a user does not have any bookmarklets"
   },
   "add_scripts_button": {
@@ -26,5 +26,13 @@
   "send_feedback_button": {
     "message": "Send feedback",
     "description": "Button label to send feedback to developer"
+  },
+  "getting_started_title": {
+    "message": "Getting Started",
+    "description": "Title used on the example scripts page"
+  },
+  "getting_started_subtitle": {
+    "message": "To add a script, drag it to your Bookmarks Bar.",
+    "description": "Subtitle used to explain how to add bookmarklets to the bookmarkbar"
   }
 }

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -13,14 +13,14 @@
   },
   "no_search_results_message": {
     "message": "No scripts found.",
-    "description": ""
+    "description": "Shown when a search returns no results"
   },
   "empty_state_message": {
     "message": "You don't have any bookmark scripts.",
-    "description": ""
+    "description": "Shown when a user does not have any bookmarklets"
   },
   "add_scripts_button": {
     "message": "Add scripts",
-    "description": ""
+    "description": "Button label to take you to script example page"
   }
 }

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -22,5 +22,9 @@
   "add_scripts_button": {
     "message": "Add scripts",
     "description": "Button label to take you to script example page"
+  },
+  "send_feedback_button": {
+    "message": "Send feedback",
+    "description": "Button label to send feedback to developer"
   }
 }

--- a/src/_locales/ja/messages.json
+++ b/src/_locales/ja/messages.json
@@ -22,5 +22,9 @@
   "add_scripts_button": {
     "message": "ブックマークレットトを追加",
     "description": ""
+  },
+  "send_feedback_button": {
+    "message": "フィードバックを送信",
+    "description": ""
   }
 }

--- a/src/_locales/ja/messages.json
+++ b/src/_locales/ja/messages.json
@@ -26,5 +26,13 @@
   "send_feedback_button": {
     "message": "フィードバックを送信",
     "description": ""
+  },
+  "getting_started_title": {
+    "message": "さあ始めましょう",
+    "description": ""
+  },
+  "getting_started_subtitle": {
+    "message": "「ブックマークバー」にブックマークレットを左クリックで選択して「ドラッグ&ドロップ」するだけです。",
+    "description": ""
   }
 }

--- a/src/_locales/ja/messages.json
+++ b/src/_locales/ja/messages.json
@@ -1,0 +1,26 @@
+{
+  "search_scripts_placeholder": {
+    "message": "スクリプトを探す",
+    "description": "Placeholder displayed in the search field for filtering scripts"
+  },
+  "recently_used_heading": {
+    "message": "最近使った",
+    "description": "Heading title for recently used scripts"
+  },
+  "other_scripts_heading": {
+    "message": "その他スクリプト",
+    "description": "Heading title for other un-grouped scripts"
+  },
+  "no_search_results_message": {
+    "message": "No scripts found.",
+    "description": ""
+  },
+  "empty_state_message": {
+    "message": "You don't have any bookmark scripts.",
+    "description": ""
+  },
+  "add_scripts_button": {
+    "message": "Add scripts",
+    "description": ""
+  }
+}

--- a/src/_locales/ja/messages.json
+++ b/src/_locales/ja/messages.json
@@ -1,26 +1,26 @@
 {
   "search_scripts_placeholder": {
-    "message": "スクリプトを探す",
-    "description": "Placeholder displayed in the search field for filtering scripts"
+    "message": "スクリプトを検索する",
+    "description": ""
   },
   "recently_used_heading": {
     "message": "最近使った",
-    "description": "Heading title for recently used scripts"
+    "description": ""
   },
   "other_scripts_heading": {
-    "message": "その他スクリプト",
-    "description": "Heading title for other un-grouped scripts"
+    "message": "その他",
+    "description": ""
   },
   "no_search_results_message": {
-    "message": "No scripts found.",
+    "message": "一致する情報はありません",
     "description": ""
   },
   "empty_state_message": {
-    "message": "You don't have any bookmark scripts.",
+    "message": "ありません",
     "description": ""
   },
   "add_scripts_button": {
-    "message": "Add scripts",
+    "message": "ブックマークレットトを追加",
     "description": ""
   }
 }

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -4,6 +4,7 @@
   "version": "1.2.0",
   "description": "Quickly find and run your bookmarklets.",
   "permissions": ["activeTab", "bookmarks"],
+  "default_locale": "en",
   "background": {
     "scripts": ["background.bundle.js"],
     "persistent": false

--- a/src/pages/examples.html
+++ b/src/pages/examples.html
@@ -62,11 +62,11 @@
 </head>
 <body>
   <main>
-    <h1>
+    <h1 data-translation-key="getting_started_title">
       Getting Started
     </h1>
 
-    <h2>
+    <h2 data-translation-key="getting_started_subtitle">
       To add a script, drag it to your Bookmarks Bar.
     </h2>
 
@@ -103,6 +103,6 @@
     </a>
   </main>
 
-  <script src="content.bundle.js"></script>
+  <script src="examples.js"></script>
 </body>
 </html>

--- a/src/pages/examples.js
+++ b/src/pages/examples.js
@@ -1,0 +1,10 @@
+const translationElements = document.querySelectorAll('[data-translation-key]');
+
+Array.from(translationElements).forEach((element) => {
+  const key = element.getAttribute('data-translation-key');
+  const translation = chrome.i18n.getMessage(key);
+
+  if (translation) {
+    element.textContent = translation;
+  }
+});

--- a/src/popup/app.jsx
+++ b/src/popup/app.jsx
@@ -3,6 +3,7 @@ import { useDispatch } from 'react-redux';
 
 import zipObject from '../utils/zipObject';
 import { firePageView } from './store/actions/stats';
+import { fetchLocaleMessages } from './store/actions/locale';
 import HomeScreen from './screens/home_screen';
 const SettingsScreen = React.lazy(() => import('./screens/settings'));
 const EditorScreen = React.lazy(() => import('./screens/editor_screen'));
@@ -40,6 +41,10 @@ export default function App() {
   useEffect(() => {
     dispatch(firePageView());
   }, [path]);
+
+  useEffect(() => {
+    dispatch(fetchLocaleMessages());
+  }, []);
 
   return (
     <div className="app">

--- a/src/popup/components/onboard_message/index.jsx
+++ b/src/popup/components/onboard_message/index.jsx
@@ -1,13 +1,15 @@
 import React from 'react';
-import { useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 
 import { navigateTo } from '../../store/actions/ui';
+import { selectTranslations } from '../../store/selectors/locale';
 import Button from '../button';
 
 import './onboard_message.css';
 
 export default function OnboardMessage() {
   const dispatch = useDispatch();
+  const translations = useSelector(selectTranslations);
 
   const handleExampleOnClick = () => {
     dispatch(navigateTo('examples.html'));
@@ -16,12 +18,12 @@ export default function OnboardMessage() {
   return (
     <div className="onboard-message">
       <div className="onboard-message__message">
-        You don't have any
-        <br />
-        bookmark&nbsp;scripts.
+        {translations['empty_state_message']}
       </div>
 
-      <Button onClick={handleExampleOnClick}>Add scripts</Button>
+      <Button onClick={handleExampleOnClick}>
+        {translations['add_scripts_button']}
+      </Button>
     </div>
   );
 }

--- a/src/popup/screens/home_screen/index.jsx
+++ b/src/popup/screens/home_screen/index.jsx
@@ -16,7 +16,7 @@ import OnboardMessage from '../../components/onboard_message';
 
 import './home_screen.css';
 
-const ENABLE_GROUPS = true;
+const ENABLE_GROUPS = false;
 
 export default function HomeScreen() {
   const dispatch = useDispatch();

--- a/src/popup/screens/home_screen/index.jsx
+++ b/src/popup/screens/home_screen/index.jsx
@@ -6,6 +6,7 @@ import {
   executeBookmarklet
 } from '../../store/actions/bookmarklets';
 import { selectBookmarkletsWithGroup } from '../../store/selectors/bookmarklets';
+import { selectTranslations } from '../../store/selectors/locale';
 import useFuzzyFilter from './use_fuzzy_filter';
 import useSortByRecent from './use_sort_by_recent';
 import SearchField from '../../components/search_field';
@@ -15,12 +16,13 @@ import OnboardMessage from '../../components/onboard_message';
 
 import './home_screen.css';
 
-const ENABLE_GROUPS = false;
+const ENABLE_GROUPS = true;
 
 export default function HomeScreen() {
   const dispatch = useDispatch();
   const searchFieldRef = useRef(null);
   const [inputFocused, setInputFocused] = useState(false);
+  const translations = useSelector(selectTranslations);
   const bookmarklets = useSelector(selectBookmarkletsWithGroup);
   const [fuzzyFilterResults, fuzzyFilter] = useFuzzyFilter(bookmarklets);
 
@@ -30,8 +32,8 @@ export default function HomeScreen() {
   const results = ENABLE_GROUPS ? sortedResults : fuzzyFilterResults;
   const listGroups = ENABLE_GROUPS
     ? [
-        { id: 'recent', title: 'Recently used' },
-        { id: null, title: 'Other scripts' }
+        { id: 'recent', title: translations['recently_used_heading'] },
+        { id: null, title: translations['other_scripts_heading'] }
       ]
     : [];
 
@@ -72,7 +74,7 @@ export default function HomeScreen() {
         onChange={handleInputChange}
         onFocus={handleInputFocus}
         onBlur={handleInputBlur}
-        placeholder="Search scripts"
+        placeholder={translations['search_scripts_placeholder']}
       />
 
       {bookmarklets.length !== 0 && (

--- a/src/popup/store/actions/locale.js
+++ b/src/popup/store/actions/locale.js
@@ -15,6 +15,7 @@ export function fetchLocaleMessages() {
     // actual translations.
     // TODO: Is this fine? Duplicate data technically. Ideally I'd like to
     // reference `_locales/` that already exists in dist.
+    // https://webpack.js.org/guides/asset-modules/
     const localeMessages = await import('../../../_locales/en/messages.json');
 
     const messages = Object.keys(localeMessages).reduce(

--- a/src/popup/store/actions/locale.js
+++ b/src/popup/store/actions/locale.js
@@ -1,6 +1,3 @@
-// TODO: Import reference to file instead of bundling JSON file into bundle.
-import localeMessages from '../../../_locales/en/messages.json';
-
 export const SET_MESSAGES = 'SET_MESSAGES';
 
 export function setMessages(messages = {}) {
@@ -14,6 +11,12 @@ export function setMessages(messages = {}) {
 
 export function fetchLocaleMessages() {
   return async (dispatch, getState, { browser }) => {
+    // Used to get the locale message keys. It does not use this to get the
+    // actual translations.
+    // TODO: Is this fine? Duplicate data technically. Ideally I'd like to
+    // reference `_locales/` that already exists in dist.
+    const localeMessages = await import('../../../_locales/en/messages.json');
+
     const messages = Object.keys(localeMessages).reduce(
       (reducedMessages, localeMessageKey) => {
         reducedMessages[localeMessageKey] = browser.i18n.getMessage(

--- a/src/popup/store/actions/locale.js
+++ b/src/popup/store/actions/locale.js
@@ -1,0 +1,29 @@
+// TODO: Import reference to file instead of bundling JSON file into bundle.
+import localeMessages from '../../../_locales/en/messages.json';
+
+export const SET_MESSAGES = 'SET_MESSAGES';
+
+export function setMessages(messages = {}) {
+  console.log('setMessages', messages);
+
+  return {
+    type: SET_MESSAGES,
+    payload: messages
+  };
+}
+
+export function fetchLocaleMessages() {
+  return async (dispatch, getState, { browser }) => {
+    const messages = Object.keys(localeMessages).reduce(
+      (reducedMessages, localeMessageKey) => {
+        reducedMessages[localeMessageKey] = browser.i18n.getMessage(
+          localeMessageKey
+        );
+        return reducedMessages;
+      },
+      {}
+    );
+
+    dispatch(setMessages(messages));
+  };
+}

--- a/src/popup/store/actions/locale.js
+++ b/src/popup/store/actions/locale.js
@@ -1,8 +1,6 @@
 export const SET_MESSAGES = 'SET_MESSAGES';
 
 export function setMessages(messages = {}) {
-  console.log('setMessages', messages);
-
   return {
     type: SET_MESSAGES,
     payload: messages
@@ -11,11 +9,11 @@ export function setMessages(messages = {}) {
 
 export function fetchLocaleMessages() {
   return async (dispatch, getState, { browser }) => {
-    // Used to get the locale message keys. It does not use this to get the
-    // actual translations.
-    // TODO: Is this fine? Duplicate data technically. Ideally I'd like to
-    // reference `_locales/` that already exists in dist.
-    // https://webpack.js.org/guides/asset-modules/
+    // Dynamic import is used to get the locale message **keys** and
+    // not the actual translation strings.
+    // TODO: Is this fine? Data is duplicated, ideally I'd like to reference
+    // `_locales/` that already exists in dist. Look into how to do this with
+    // Wwebpack 5: https://webpack.js.org/guides/asset-modules/
     const localeMessages = await import('../../../_locales/en/messages.json');
 
     const messages = Object.keys(localeMessages).reduce(

--- a/src/popup/store/reducers/index.js
+++ b/src/popup/store/reducers/index.js
@@ -5,6 +5,7 @@ import storage from 'redux-persist/lib/storage';
 import bookmarklets from './bookmarklets';
 import ui from './ui';
 import editor from './editor';
+import locale from './locale';
 
 const bookmarkletsPersistConfig = {
   key: 'bookmarklets',
@@ -15,5 +16,6 @@ const bookmarkletsPersistConfig = {
 export default combineReducers({
   bookmarklets: persistReducer(bookmarkletsPersistConfig, bookmarklets),
   ui,
-  editor
+  editor,
+  locale
 });

--- a/src/popup/store/reducers/locale.js
+++ b/src/popup/store/reducers/locale.js
@@ -1,0 +1,17 @@
+import { SET_MESSAGES } from '../actions/locale';
+
+const defaultState = {
+  messages: {}
+};
+
+export default function  localeReducer(state = defaultState, action) {
+  switch (action.type) {
+    case SET_MESSAGES:
+      return {
+        ...state,
+        messages: action.payload
+      };
+    default:
+      return state;
+  }
+}

--- a/src/popup/store/reducers/locale.js
+++ b/src/popup/store/reducers/locale.js
@@ -4,7 +4,7 @@ const defaultState = {
   messages: {}
 };
 
-export default function  localeReducer(state = defaultState, action) {
+export default function localeReducer(state = defaultState, action) {
   switch (action.type) {
     case SET_MESSAGES:
       return {

--- a/src/popup/store/selectors/locale.js
+++ b/src/popup/store/selectors/locale.js
@@ -1,0 +1,10 @@
+import { createSelector } from 'reselect';
+
+const selectLocaleMessages = (state) => state.locale.messages;
+
+export const selectTranslations = createSelector(
+  selectLocaleMessages,
+  (messages) => {
+    return messages;
+  }
+);

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -42,7 +42,8 @@ module.exports = {
     new CopyPlugin([
       './src/manifest.json',
       './src/pages/examples.html',
-      './assets'
+      './assets',
+      { from: './src/_locales', to: '_locales' }
     ]),
     new HtmlWebpackPlugin({
       title: 'Powerlet',

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -42,6 +42,7 @@ module.exports = {
     new CopyPlugin([
       './src/manifest.json',
       './src/pages/examples.html',
+      './src/pages/examples.js',
       './assets',
       { from: './src/_locales', to: '_locales' }
     ]),


### PR DESCRIPTION
## Changes
- Add support for translations
- Add basic Japanese translation strings. Though still need to verify these are good enough
- Used [Chromium translation strings](https://translations.launchpad.net/chromium-browser/translations/+pots/chromium-browser/ja/+translate?batch=10&show=all&search=search) as example for mine

This PR replaces the old one: https://github.com/anthonyec/powerlet/pull/48