### PR TITLE
Fix React setup issues to use React 18

### DIFF
--- a/src/popup/index.ejs
+++ b/src/popup/index.ejs
@@ -3,7 +3,9 @@
   <head>
     <meta charset="UTF-8">
   </head>
-  <body id="root">
-    <div class="app"></div>
+  <body>
+    <div id="root">
+      <div class="app"></div>
+    </div>
   </body>
 </html>

--- a/src/popup/index.js
+++ b/src/popup/index.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
+import { createRoot } from 'react-dom/client';
 import { Provider } from 'react-redux';
 import { persistStore } from 'redux-persist';
 import createStats from 'simple-plausible-tracker';
@@ -27,13 +27,14 @@ const store = createStore(
 
 persistStore(store);
 
-ReactDOM.render(
+const root = createRoot(document.getElementById('root'));
+
+root.render(
   <Provider store={store}>
     <ToastProvider>
       <UndoHistoryProvider>
         <App />
       </UndoHistoryProvider>
     </ToastProvider>
-  </Provider>,
-  document.getElementById('root')
+  </Provider>
 );


### PR DESCRIPTION
## Changes
- Use `createRoot` to enable React 18
- Fix warning about using `<body>` as app root by creating separate `<div>`