### PR TITLE
Fix non-existent recently used bookmarks to cause group headings to show

### DIFF
--- a/src/popup/screens/home_screen/index.jsx
+++ b/src/popup/screens/home_screen/index.jsx
@@ -10,7 +10,8 @@ import { useSelector, useDispatch } from 'react-redux';
 
 import {
   fetchAllBookmarklets,
-  executeBookmarklet
+  executeBookmarklet,
+  removeNonExistentRecents
 } from '../../store/actions/bookmarklets';
 import {
   selectBookmarkletGroups,
@@ -64,6 +65,7 @@ export default function HomeScreen() {
 
     const handleBookmarksChange = () => {
       dispatch(fetchAllBookmarklets());
+      dispatch(removeNonExistentRecents());
     };
 
     handleBookmarksChange();

--- a/src/popup/store/actions/bookmarklets.js
+++ b/src/popup/store/actions/bookmarklets.js
@@ -69,7 +69,7 @@ export function removeNonExistentRecents() {
     const results = await Promise.allSettled(getBookmarkPromises);
 
     for (const result of results) {
-      if (result.status === 'rejected') {
+      if (result.status === 'rejected' && result.reason) {
         dispatch(removeRecentBookmarklet(result.reason));
       }
     }

--- a/src/popup/store/actions/bookmarklets.js
+++ b/src/popup/store/actions/bookmarklets.js
@@ -47,6 +47,35 @@ export function executeBookmarklet(id, url) {
   };
 }
 
+// Clean up any recently used bookmarks that no longer exist.
+export function removeNonExistentRecents() {
+  return async (dispatch, getState, { browser }) => {
+    const { bookmarklets } = getState();
+
+    const getBookmarkPromises = bookmarklets.recent.map((id) => {
+      return new Promise((resolve, reject) => {
+        browser.bookmarks.get(id, (result) => {
+          if (browser.runtime.lastError) {
+            reject(id);
+          }
+
+          if (result) {
+            resolve(id);
+          }
+        });
+      });
+    });
+
+    const results = await Promise.allSettled(getBookmarkPromises);
+
+    for (const result of results) {
+      if (result.status === 'rejected') {
+        dispatch(removeRecentBookmarklet(result.reason));
+      }
+    }
+  };
+}
+
 export function fetchAllBookmarklets() {
   return (dispatch, getState, { browser }) => {
     browser.bookmarks.search(


### PR DESCRIPTION
# Changes
- Fire another action when fetching bookmarks that will clean up any non-existent bookmark IDs in recently used