### PR TITLE
Fixes for edit script screen

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -78,5 +78,17 @@
   "move_to_group_label": {
     "message": "Move to \"%s\"",
     "description": "Move to a specific group action label"
+  },
+  "script_not_visible_toast": {
+    "message": "\"%s\" is not visible because it's not a bookmarklet.",
+    "description": "Message displayed when the script is not a valid bookmarklet"
+  },
+  "fix_label": {
+    "message": "Fix",
+    "description": "Label for button to fix a script"
+  },
+  "script_missing_keyword_message": {
+    "message": "Scripts need to start with the keyword \"javascript:\".",
+    "description": "Message shown when the script is missing the 'javascript': keyword at the start"
   }
 }

--- a/src/_locales/ja/messages.json
+++ b/src/_locales/ja/messages.json
@@ -69,7 +69,7 @@
   },
   "undo_label": {
     "message": "取消",
-    "description": "Message displayed when a script is deleted"
+    "description": ""
   },
   "edit_label": {
     "message": "編集",
@@ -77,6 +77,18 @@
   },
   "move_to_group_label": {
     "message": "\"%s\"に移動",
+    "description": ""
+  },
+  "script_not_visible_toast": {
+    "message": "\"%s\"スクリプトが無効です",
+    "description": "Note this translation only mentions the script is invalid, not hidden"
+  },
+  "fix_label": {
+    "message": "修正",
+    "description": ""
+  },
+  "script_missing_keyword_message": {
+    "message": "スクリプトはキーワード「javascript:」で開始する必要があります。",
     "description": ""
   }
 }

--- a/src/popup/app.jsx
+++ b/src/popup/app.jsx
@@ -1,4 +1,4 @@
-import React, { Suspense, useEffect, useState } from 'react';
+import React, { Suspense, startTransition, useEffect, useState } from 'react';
 import { useDispatch } from 'react-redux';
 
 import zipObject from '../utils/zipObject';
@@ -51,7 +51,9 @@ export default function App() {
 
   useEffect(() => {
     const handleHashChange = () => {
-      setPath(parseHash(window.location.hash));
+      startTransition(() => {
+        setPath(parseHash(window.location.hash));
+      });
     };
 
     // Fetch translations on load.

--- a/src/popup/components/toast/index.jsx
+++ b/src/popup/components/toast/index.jsx
@@ -3,12 +3,24 @@ import React from 'react';
 import './toast.css';
 
 export default function Toast({
+  inline,
+  warning,
   message = '',
   label = '',
   onActionClick = () => {}
 }) {
+  let className = 'toast';
+
+  if (inline) {
+    className += ' toast--inline';
+  }
+
+  if (warning) {
+    className += ' toast--warning';
+  }
+
   return (
-    <div className="toast">
+    <div className={className}>
       {message}
       <button className="toast__button" onClick={onActionClick}>
         {label}

--- a/src/popup/components/toast/toast.css
+++ b/src/popup/components/toast/toast.css
@@ -12,6 +12,17 @@
   user-select: none;
 }
 
+.toast--inline {
+  padding: 0;
+  box-shadow: none;
+  background: none;
+  border-radius: 0;
+}
+
+.toast--warning {
+  color: var(--button-danger-color);
+}
+
 .toast__button {
   color: var(--toast-action-color);
   background: transparent;

--- a/src/popup/components/toast/toast.css
+++ b/src/popup/components/toast/toast.css
@@ -35,6 +35,7 @@
   padding: 0 8px;
   font-weight: 600;
   margin-right: -8px;
+  flex-shrink: 0;
 }
 
 .toast__button:active {

--- a/src/popup/hooks/use_browser_bookmarks.js
+++ b/src/popup/hooks/use_browser_bookmarks.js
@@ -8,6 +8,7 @@ import {
 } from '../store/actions/bookmarklets';
 import { useToast } from './use_toast';
 import { useUndoHistory } from './use_undo_history';
+import clampText from '../lib/clamp_text';
 
 export function useBrowserBookmarks() {
   const dispatch = useDispatch();
@@ -93,7 +94,7 @@ export function useBrowserBookmarks() {
         toast.show({
           message: translations['script_deleted_toast'].replace(
             '%s',
-            bookmark.title || 'Untitled script'
+            clampText(bookmark.title) || 'Untitled script'
           ),
           label: translations['undo_label'],
           action: undoHistory.pop

--- a/src/popup/lib/clamp_text.js
+++ b/src/popup/lib/clamp_text.js
@@ -1,0 +1,7 @@
+export default function clampText(text = '', maxLength = 20) {
+  if (text.length > maxLength) {
+    return text.slice(0, maxLength) + '…';
+  }
+
+  return text;
+}

--- a/src/popup/screens/edit_bookmarklet_screen/index.jsx
+++ b/src/popup/screens/edit_bookmarklet_screen/index.jsx
@@ -82,8 +82,11 @@ export default function EditBookmarkletScreen({
   const handleBackClick = () => {
     if (bookmarklet.url.trim() && !bookmarklet.url.startsWith('javascript:')) {
       toast.show({
-        message: `"${bookmarklet.title}" is not visible.`,
-        label: 'Fix',
+        message: translations['script_not_visible_toast'].replace(
+          '%s',
+          bookmarklet.title
+        ),
+        label: translations['fix_label'],
         action: () => {
           window.location.hash = `edit/${bookmarklet.id}`;
         }
@@ -142,8 +145,8 @@ export default function EditBookmarkletScreen({
             <Toast
               inline
               warning
-              message={`Scripts need to start with the keyword "javascript:".`}
-              label="Fix"
+              message={translations['script_missing_keyword_message']}
+              label={translations['fix_label']}
               onActionClick={handleToastActionClick}
             />
           </div>

--- a/src/popup/screens/edit_bookmarklet_screen/index.jsx
+++ b/src/popup/screens/edit_bookmarklet_screen/index.jsx
@@ -23,7 +23,10 @@ export default function EditBookmarkletScreen({
   }, []);
 
   useEffect(() => {
-    if (!route.params.id) return;
+    if (!route.params.id) {
+      window.location.hash = '';
+      return;
+    }
 
     if (route.params.id === 'new') {
       const newBookmarklet = {
@@ -56,11 +59,9 @@ export default function EditBookmarkletScreen({
     };
 
     handleBookmarksChange();
-    chrome.bookmarks.onChanged.addListener(handleBookmarksChange);
     chrome.bookmarks.onRemoved.addListener(handleBookmarksChange);
 
     return () => {
-      chrome.bookmarks.onChanged.removeListener(handleBookmarksChange);
       chrome.bookmarks.onRemoved.removeListener(handleBookmarksChange);
     };
   }, [route.params.id]);

--- a/src/popup/screens/edit_bookmarklet_screen/index.jsx
+++ b/src/popup/screens/edit_bookmarklet_screen/index.jsx
@@ -111,17 +111,6 @@ export default function EditBookmarkletScreen({
     setBookmarklet({ ...bookmarklet, url: code });
   };
 
-  if (!bookmarklet) {
-    return (
-      <div className="edit-bookmarklet-screen">
-        <Titlebar
-          title={translations['edit_script_title']}
-          onBackClick={handleBackClick}
-        />
-      </div>
-    );
-  }
-
   return (
     <div className="edit-bookmarklet-screen">
       <Titlebar
@@ -132,16 +121,16 @@ export default function EditBookmarkletScreen({
       <div className="edit-bookmarklet-screen__content">
         <TextField
           label={translations['name_field_label']}
-          defaultValue={bookmarklet.title}
+          defaultValue={bookmarklet?.title || ''}
           onChange={handleTitleChange}
         />
         <TextField
           label={translations['code_field_label']}
-          defaultValue={bookmarklet.url}
+          defaultValue={bookmarklet?.url || ''}
           onChange={handleCodeChange}
         />
 
-        {!bookmarklet.url.startsWith('javascript:') && (
+        {bookmarklet !== null && !bookmarklet.url.startsWith('javascript:') && (
           <div style={{ marginLeft: 58 }}>
             <Toast
               inline

--- a/src/popup/screens/edit_bookmarklet_screen/index.jsx
+++ b/src/popup/screens/edit_bookmarklet_screen/index.jsx
@@ -8,6 +8,7 @@ import Toast from '../../components/toast';
 import { selectTranslations } from '../../store/selectors/locale';
 import { useBrowserBookmarks } from '../../hooks/use_browser_bookmarks';
 import { useToast } from '../../hooks/use_toast';
+import clampText from '../../lib/clamp_text';
 
 import './edit_bookmarklet_screen.css';
 
@@ -84,7 +85,7 @@ export default function EditBookmarkletScreen({
       toast.show({
         message: translations['script_not_visible_toast'].replace(
           '%s',
-          bookmarklet.title
+          clampText(bookmarklet.title)
         ),
         label: translations['fix_label'],
         action: () => {


### PR DESCRIPTION
## Changes
- Show edit screen UI before bookmark has loaded
- Create inline and warning variant of `Toast` component
- Show warning when script is not valid and won't be visible
- Clamp bookmark title in toast to limit the height of the notification
- Remove on change events from edit screen because it causes weird feedback loops. Changes are only reflected in local state and when first loading a bookmark to edit
- Use React `startTransition` when loading a new route. It _should_ prevent `Suspense` showing a fallback but I'm not actually sure it's working. May remove later