### PR TITLE
Add popup window blocker fix

### DIFF
--- a/src/background/index.js
+++ b/src/background/index.js
@@ -236,7 +236,7 @@ chrome.runtime.onMessage.addListener(async (message, _sender, respond) => {
     respond({ type: identifiers.pongEvent });
 
     const { supportsUserScripts: wasUserScriptsEnabled } =
-      await chrome.storage.local.get('supportsUserScripts');
+      await chrome.storage.local.get('environment:supportsUserScripts');
 
     if (!wasUserScriptsEnabled && isUserScriptsEnabled) {
       reloadAllUserScripts();
@@ -245,7 +245,9 @@ chrome.runtime.onMessage.addListener(async (message, _sender, respond) => {
 
   // Any event handlers after this require user script support. If it's not
   // supported, don't handle those events.
-  await chrome.storage.local.set({ supportsUserScripts: isUserScriptsEnabled });
+  await chrome.storage.local.set({
+    'environment:supportsUserScripts': isUserScriptsEnabled
+  });
   if (!isUserScriptsEnabled) return;
 
   if (message.type === identifiers.executeBookmarkletEvent) {

--- a/src/content/isolated.js
+++ b/src/content/isolated.js
@@ -4,6 +4,19 @@ import { createLogger } from '../utils/logger';
 
 const logger = createLogger('content_isolated');
 
+function invokeProxyFunction(name, args = []) {
+  switch (name) {
+    case 'open': {
+      window.open(...args);
+      break;
+    }
+
+    default: {
+      logger.error(`No proxy function found for: ${name}`);
+    }
+  }
+}
+
 // Bridge all runtime events from the extension to window events, and vice versa.
 chrome.runtime.onMessage.addListener((message) => {
   if (!isMessage(message)) return;
@@ -22,6 +35,16 @@ window.addEventListener(identifiers.messageToIsolatedScript, (event) => {
   if (!isMessage(message)) return;
 
   logger.log('on_window_message', message);
+
+  if (message.type === identifiers.invokeProxyFunction) {
+    // Catch invoke proxy function events here to preventing them from ending up
+    // in the the background worker. This is because we have access to
+    // `window.open` in isolated content, and can open up windows without Chrome
+    // popup blocker stopping them. Popup windows are blocked in the main
+    // content script.
+    invokeProxyFunction(message.name, message.args);
+    return;
+  }
 
   chrome.runtime.sendMessage(message);
 });

--- a/src/content/main.js
+++ b/src/content/main.js
@@ -32,7 +32,13 @@ function queueAndReload(bookmarkId, tabId) {
   sendMessage({ type: identifiers.queueAndReloadEvent, bookmarkId, tabId });
 }
 
-function executeBookmarklet(bookmarkId, tabId, currentHash, retry = true) {
+function executeBookmarklet(
+  bookmarkId,
+  tabId,
+  currentHash,
+  retry = true,
+  settings = {}
+) {
   const bookmarklet = getPowerletBookmarkletFunction(bookmarkId);
 
   if (retry && !bookmarklet) {
@@ -50,11 +56,15 @@ function executeBookmarklet(bookmarkId, tabId, currentHash, retry = true) {
   }
 
   try {
-    bookmarklet();
+    bookmarklet(settings);
   } catch (err) {
     alert(`Failed to run bookmarklet:\n${err}`);
   }
 }
+
+window[identifiers.invokeProxyFunction] = (name, args = []) => {
+  sendMessage({ type: identifiers.invokeProxyFunction, name, args });
+};
 
 window.addEventListener(identifiers.messageToContentScript, (event) => {
   const message = event.detail;
@@ -72,7 +82,8 @@ window.addEventListener(identifiers.messageToContentScript, (event) => {
       message.bookmarkId,
       message.tabId,
       message.hash,
-      message.retry
+      message.retry,
+      message.settings
     );
   }
 });

--- a/src/identifiers.js
+++ b/src/identifiers.js
@@ -1,5 +1,6 @@
 export const messageToContentScript = '_powerlet_message_to_content_script';
 export const messageToIsolatedScript = '_powerlet_message_to_isolated_script';
+export const invokeProxyFunction = '_powerlet_invoke_proxy_function';
 export const executeBookmarkletEvent = '_powerlet_execute_bookmarklet';
 export const startExecuteBookmarkletEvent =
   '_powerlet_start_execute_bookmarklet';

--- a/src/popup/components/control_row/control_row.css
+++ b/src/popup/components/control_row/control_row.css
@@ -1,0 +1,18 @@
+.control-row {
+  display: flex;
+}
+
+.control-row__label {
+  display: flex;
+  width: 65px;
+  height: 32px;
+  align-items: center;
+  flex-shrink: 0;
+}
+
+.control-row__control {
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+  width: 100%;
+}

--- a/src/popup/components/control_row/index.jsx
+++ b/src/popup/components/control_row/index.jsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+import './control_row.css';
+
+export function ControlRow({ label, visible = true, children }) {
+  return (
+    <div className="control-row">
+      <div className="control-row__label">{label}</div>
+      {visible && <div className="control-row__control">{children}</div>}
+    </div>
+  );
+}

--- a/src/popup/components/text_field/text_field.css
+++ b/src/popup/components/text_field/text_field.css
@@ -1,13 +1,6 @@
 .text-field {
   display: flex;
-}
-
-.text-field__label {
-  display: flex;
-  width: 56px;
-  height: 32px;
-  align-items: center;
-  flex-shrink: 0;
+  width: 100%;
 }
 
 .text-field__input {

--- a/src/popup/components/toggle/index.jsx
+++ b/src/popup/components/toggle/index.jsx
@@ -1,0 +1,13 @@
+import React from 'react';
+
+import './toggle.css';
+
+export function Toggle() {
+  return (
+    <div className="toggle">
+      <input className="toggle__input" type="checkbox" />
+      <div className="toggle__track" />
+      <div className="toggle__knob" />
+    </div>
+  );
+}

--- a/src/popup/components/toggle/index.jsx
+++ b/src/popup/components/toggle/index.jsx
@@ -4,7 +4,7 @@ import './toggle.css';
 
 export function Toggle({ value, onChange }) {
   return (
-    <div className="toggle">
+    <label className="toggle">
       <input
         className="toggle__input"
         type="checkbox"
@@ -13,6 +13,6 @@ export function Toggle({ value, onChange }) {
       />
       <div className="toggle__track" />
       <div className="toggle__knob" />
-    </div>
+    </label>
   );
 }

--- a/src/popup/components/toggle/index.jsx
+++ b/src/popup/components/toggle/index.jsx
@@ -2,10 +2,15 @@ import React from 'react';
 
 import './toggle.css';
 
-export function Toggle() {
+export function Toggle({ value, onChange }) {
   return (
     <div className="toggle">
-      <input className="toggle__input" type="checkbox" />
+      <input
+        className="toggle__input"
+        type="checkbox"
+        checked={value}
+        onChange={onChange}
+      />
       <div className="toggle__track" />
       <div className="toggle__knob" />
     </div>

--- a/src/popup/components/toggle/index.jsx
+++ b/src/popup/components/toggle/index.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import './toggle.css';
 
-export function Toggle({ value, onChange }) {
+export default function Toggle({ value, onChange }) {
   return (
     <label className="toggle">
       <input

--- a/src/popup/components/toggle/toggle.css
+++ b/src/popup/components/toggle/toggle.css
@@ -5,6 +5,13 @@
   position: relative;
 }
 
+/* Increase hit area of toggle. */
+.toggle::after {
+  content: "";
+  inset: -10px;
+  position: absolute;
+}
+
 .toggle:focus-within {
   box-shadow: 0 0 0 2px var(--global-background), 0 0 0 4px var(--global-focus-border-color);
 }

--- a/src/popup/components/toggle/toggle.css
+++ b/src/popup/components/toggle/toggle.css
@@ -1,0 +1,66 @@
+.toggle {
+  border-radius: 100px;
+  width: 26px;
+  height: 16px;
+  position: relative;
+}
+
+.toggle:focus-within {
+  box-shadow: 0 0 0 2px var(--global-background), 0 0 0 4px var(--global-focus-border-color);
+}
+
+.toggle__track {
+  background: #454746;
+  border: 1px solid #8F918F;
+  border-radius: 100px;
+  width: 100%;
+  height: 100%;
+  transition: all 100ms ease;
+  position: absolute;
+  z-index: 1;
+}
+
+.toggle__input:checked ~ .toggle__track {
+  background: #A8C7FA;
+  border: 1px solid #A8C7FA;
+}
+
+.toggle__input {
+  inset: 0;
+  opacity: 0;
+  position: absolute;
+  z-index: 3;
+}
+
+.toggle__knob {
+  width: 17px;
+  height: 100%;
+  top: 0;
+  transform: translateX(-1px);
+  transition: transform 150ms ease;
+  position: absolute;
+  z-index: 2;
+}
+
+.toggle__input:checked ~ .toggle__knob {
+  transform: translateX(10px);
+}
+
+.toggle__knob::after {
+  content: "";
+  background: #8F918F;
+  border-radius: 100px;
+  position: absolute;
+  width: 8px;
+  height: 8px;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  transition: all 150ms ease;
+}
+
+.toggle__input:checked ~ .toggle__knob::after {
+  background: #062E6F;
+  width: 12px;
+  height: 12px;
+}

--- a/src/popup/hooks/use_browser_local_storage.js
+++ b/src/popup/hooks/use_browser_local_storage.js
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
+
 import { createBrowserLocalStorage } from '../../utils/browser_local_storage';
 
 export function useBrowserLocalStorage(

--- a/src/popup/hooks/use_browser_local_storage.js
+++ b/src/popup/hooks/use_browser_local_storage.js
@@ -1,8 +1,5 @@
-import { useEffect, useState } from 'react';
-
-function removeNamespaceFromKey(namespace, namespacedKey) {
-  return namespacedKey.replace(`${namespace}:`, '');
-}
+import { useEffect, useRef, useState } from 'react';
+import { createBrowserLocalStorage } from '../../utils/browser_local_storage';
 
 export function useBrowserLocalStorage(
   namespace = 'global',
@@ -11,61 +8,16 @@ export function useBrowserLocalStorage(
   const [loaded, setLoaded] = useState(false);
   const [values, setValues] = useState(initialValues);
 
+  const storage = useRef(
+    createBrowserLocalStorage(namespace, initialValues, (changes) =>
+      setValues(changes)
+    )
+  );
+
   useEffect(() => {
-    const handleStorageChange = (changes = {}) => {
-      const namespacedKeys = Object.keys(changes);
-      const newValues = {};
-
-      for (const namespacedKey of namespacedKeys) {
-        const key = removeNamespaceFromKey(namespace, namespacedKey);
-        newValues[key] = changes[namespacedKey].newValue;
-      }
-
-      setValues({ ...values, ...newValues });
-    };
-
-    const loadStoredValues = async () => {
-      const storedValues = await chrome.storage.local.get(null);
-
-      const newValues = {};
-
-      for (const [namespacedKey, value] of Object.entries(storedValues)) {
-        const key = removeNamespaceFromKey(namespace, namespacedKey);
-
-        const initialValue = typeof initialValues[key] !== 'undefined';
-        if (!initialValue) continue;
-
-        newValues[key] = value;
-      }
-
-      setValues({ ...values, ...newValues });
-      setLoaded(true);
-    };
-
-    chrome.storage.local.onChanged.addListener(handleStorageChange);
-    loadStoredValues();
-
-    return () => {
-      chrome.storage.local.onChanged.removeListener(handleStorageChange);
-    };
+    storage.current.getAll().then(() => setLoaded(true));
+    return storage.current.subscribe();
   }, []);
 
-  const set = (key, value) => {
-    if (!key) return;
-
-    return chrome.storage.local.set({ [`${namespace}:${key}`]: value });
-  };
-
-  const get = async (key, defaultValue) => {
-    if (!key) return;
-
-    const result = await chrome.storage.local.get(`${namespace}:${key}`);
-
-    const value = result[`${namespace}:${key}`] ?? defaultValue;
-    setValues({ [key]: value });
-
-    return value;
-  };
-
-  return { set, get, values, loaded };
+  return { set: storage.current.set, get: storage.current.get, values, loaded };
 }

--- a/src/popup/hooks/use_browser_local_storage.js
+++ b/src/popup/hooks/use_browser_local_storage.js
@@ -1,0 +1,71 @@
+import { useEffect, useState } from 'react';
+
+function removeNamespaceFromKey(namespace, namespacedKey) {
+  return namespacedKey.replace(`${namespace}:`, '');
+}
+
+export function useBrowserLocalStorage(
+  namespace = 'global',
+  initialValues = {}
+) {
+  const [loaded, setLoaded] = useState(false);
+  const [values, setValues] = useState(initialValues);
+
+  useEffect(() => {
+    const handleStorageChange = (changes = {}) => {
+      const namespacedKeys = Object.keys(changes);
+      const newValues = {};
+
+      for (const namespacedKey of namespacedKeys) {
+        const key = removeNamespaceFromKey(namespace, namespacedKey);
+        newValues[key] = changes[namespacedKey].newValue;
+      }
+
+      setValues({ ...values, ...newValues });
+    };
+
+    const loadStoredValues = async () => {
+      const storedValues = await chrome.storage.local.get(null);
+
+      const newValues = {};
+
+      for (const [namespacedKey, value] of Object.entries(storedValues)) {
+        const key = removeNamespaceFromKey(namespace, namespacedKey);
+
+        const initialValue = typeof initialValues[key] !== 'undefined';
+        if (!initialValue) continue;
+
+        newValues[key] = value;
+      }
+
+      setValues({ ...values, ...newValues });
+      setLoaded(true);
+    };
+
+    chrome.storage.local.onChanged.addListener(handleStorageChange);
+    loadStoredValues();
+
+    return () => {
+      chrome.storage.local.onChanged.removeListener(handleStorageChange);
+    };
+  }, []);
+
+  const set = (key, value) => {
+    if (!key) return;
+
+    return chrome.storage.local.set({ [`${namespace}:${key}`]: value });
+  };
+
+  const get = async (key, defaultValue) => {
+    if (!key) return;
+
+    const result = await chrome.storage.local.get(`${namespace}:${key}`);
+
+    const value = result[`${namespace}:${key}`] ?? defaultValue;
+    setValues({ [key]: value });
+
+    return value;
+  };
+
+  return { set, get, values, loaded };
+}

--- a/src/popup/screens/edit_bookmarklet_screen/index.jsx
+++ b/src/popup/screens/edit_bookmarklet_screen/index.jsx
@@ -6,13 +6,15 @@ import { ControlRow } from '../../components/control_row';
 import TextField from '../../components/text_field';
 import Titlebar from '../../components/titlebar';
 import Toast from '../../components/toast';
-import { Toggle } from '../../components/toggle';
+import Toggle from '../../components/toggle';
+
 import { useBrowserBookmarks } from '../../hooks/use_browser_bookmarks';
 import { useBrowserLocalStorage } from '../../hooks/use_browser_local_storage';
 import { useToast } from '../../hooks/use_toast';
-import clampText from '../../lib/clamp_text';
+
 import { fetchAllBookmarklets } from '../../store/actions/bookmarklets';
 import { selectTranslations } from '../../store/selectors/locale';
+import clampText from '../../lib/clamp_text';
 
 import './edit_bookmarklet_screen.css';
 

--- a/src/popup/screens/edit_bookmarklet_screen/index.jsx
+++ b/src/popup/screens/edit_bookmarklet_screen/index.jsx
@@ -2,11 +2,13 @@ import React, { useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
 import Button from '../../components/button';
+import { ControlRow } from '../../components/control_row';
 import TextField from '../../components/text_field';
 import Titlebar from '../../components/titlebar';
 import Toast from '../../components/toast';
 import { Toggle } from '../../components/toggle';
 import { useBrowserBookmarks } from '../../hooks/use_browser_bookmarks';
+import { useBrowserLocalStorage } from '../../hooks/use_browser_local_storage';
 import { useToast } from '../../hooks/use_toast';
 import clampText from '../../lib/clamp_text';
 import { fetchAllBookmarklets } from '../../store/actions/bookmarklets';
@@ -31,6 +33,10 @@ export default function EditBookmarkletScreen({
   const translations = useSelector(selectTranslations);
   const toast = useToast();
   const bookmarks = useBrowserBookmarks();
+
+  const storage = useBrowserLocalStorage(`settings_local:${route.params.id}`, {
+    allowPopups: true
+  });
 
   useEffect(() => {
     toast.hide();
@@ -123,6 +129,11 @@ export default function EditBookmarkletScreen({
     setBookmarklet({ ...bookmarklet, url: code });
   };
 
+  const handlePopupsChange = async (event) => {
+    if (!event.currentTarget) return;
+    await storage.set('allowPopups', event.currentTarget.checked);
+  };
+
   return (
     <div className="edit-bookmarklet-screen">
       <Titlebar
@@ -131,17 +142,26 @@ export default function EditBookmarkletScreen({
       />
 
       <div className="edit-bookmarklet-screen__content">
-        <TextField
-          label={translations['name_field_label']}
-          defaultValue={bookmarklet?.title || ''}
-          onChange={handleTitleChange}
-        />
-        <TextField
-          label={translations['code_field_label']}
-          defaultValue={bookmarklet?.url || ''}
-          onChange={handleCodeChange}
-        />
-        <Toggle />
+        <ControlRow label={translations['name_field_label']}>
+          <TextField
+            defaultValue={bookmarklet?.title || ''}
+            onChange={handleTitleChange}
+          />
+        </ControlRow>
+
+        <ControlRow label={translations['code_field_label']}>
+          <TextField
+            defaultValue={bookmarklet?.url || ''}
+            onChange={handleCodeChange}
+          />
+        </ControlRow>
+
+        <ControlRow label="Popups" visible={storage.loaded}>
+          <Toggle
+            value={storage.values['allowPopups']}
+            onChange={handlePopupsChange}
+          />
+        </ControlRow>
 
         {bookmarklet !== null && !bookmarklet.url.startsWith('javascript:') && (
           <div style={{ marginLeft: 58 }}>

--- a/src/popup/screens/edit_bookmarklet_screen/index.jsx
+++ b/src/popup/screens/edit_bookmarklet_screen/index.jsx
@@ -5,13 +5,14 @@ import Button from '../../components/button';
 import TextField from '../../components/text_field';
 import Titlebar from '../../components/titlebar';
 import Toast from '../../components/toast';
-import { selectTranslations } from '../../store/selectors/locale';
+import { Toggle } from '../../components/toggle';
 import { useBrowserBookmarks } from '../../hooks/use_browser_bookmarks';
 import { useToast } from '../../hooks/use_toast';
 import clampText from '../../lib/clamp_text';
+import { fetchAllBookmarklets } from '../../store/actions/bookmarklets';
+import { selectTranslations } from '../../store/selectors/locale';
 
 import './edit_bookmarklet_screen.css';
-import { fetchAllBookmarklets } from '../../store/actions/bookmarklets';
 
 function returnToHomeScreen(id) {
   if (id) {
@@ -140,6 +141,7 @@ export default function EditBookmarkletScreen({
           defaultValue={bookmarklet?.url || ''}
           onChange={handleCodeChange}
         />
+        <Toggle />
 
         {bookmarklet !== null && !bookmarklet.url.startsWith('javascript:') && (
           <div style={{ marginLeft: 58 }}>

--- a/src/utils/browser_local_storage.js
+++ b/src/utils/browser_local_storage.js
@@ -1,0 +1,74 @@
+function removeNamespaceFromKey(namespace, namespacedKey) {
+  return namespacedKey.replace(`${namespace}:`, '');
+}
+
+export function createBrowserLocalStorage(
+  namespace = 'global',
+  initialValues = {},
+  onChange = (_values = {}) => {}
+) {
+  let values = { ...initialValues };
+
+  const setValues = (newValues = {}) => {
+    values = { ...values, ...newValues };
+  };
+
+  const handleStorageChange = (changes = {}) => {
+    const namespacedKeys = Object.keys(changes);
+    const newValues = {};
+
+    for (const namespacedKey of namespacedKeys) {
+      const key = removeNamespaceFromKey(namespace, namespacedKey);
+      newValues[key] = changes[namespacedKey].newValue;
+    }
+
+    setValues({ ...values, ...newValues });
+    onChange(values);
+  };
+
+  const getAll = async () => {
+    const storedValues = await chrome.storage.local.get(null);
+
+    const newValues = {};
+
+    for (const [namespacedKey, value] of Object.entries(storedValues)) {
+      const key = removeNamespaceFromKey(namespace, namespacedKey);
+
+      const initialValue = typeof initialValues[key] !== 'undefined';
+      if (!initialValue) continue;
+
+      newValues[key] = value;
+    }
+
+    setValues({ ...values, ...newValues });
+    onChange(values);
+
+    return values;
+  };
+
+  const set = (key, value) => {
+    if (!key) return;
+
+    return chrome.storage.local.set({ [`${namespace}:${key}`]: value });
+  };
+
+  const get = async (key, defaultValue) => {
+    if (!key) return;
+
+    const result = await chrome.storage.local.get(`${namespace}:${key}`);
+
+    const value = result[`${namespace}:${key}`] ?? defaultValue;
+    setValues({ [key]: value });
+
+    return value;
+  };
+
+  const subscribe = () => {
+    chrome.storage.local.onChanged.addListener(handleStorageChange);
+
+    return () =>
+      chrome.storage.local.onChanged.removeListener(handleStorageChange);
+  };
+
+  return { get, set, getAll, subscribe };
+}


### PR DESCRIPTION
- Add popup window blocker fix
- Add option to disable the fix for bookmarklets that don't work with it (ones that require `open("").document.write`
- Add abstraction for Chrome local storage to make interacting with it a bit nicer. I don't like the way it returns an object when getting values

The fix works by proxying any calls to `window.open` to an open window function in the background script. This circumnavigates Chrome's popup blocker. 

However, it won't work with all bookmarklets since some require a reference to the opened window. In those cases, the fix can be disabled by disabling "Popups" in the bookmarklet settings.